### PR TITLE
[bugfix] Converted long double to double in `frexpl`.

### DIFF
--- a/include/math.h
+++ b/include/math.h
@@ -230,7 +230,7 @@ long double fmodl(long double, long double);
 
 double      frexp(double, int *);
 float       frexpf(float, int *);
-long double frexpl(long double, int *);
+double frexpl(double, int *);
 
 double      hypot(double, double);
 float       hypotf(float, float);

--- a/src/math/frexpl.c
+++ b/src/math/frexpl.c
@@ -1,12 +1,12 @@
 #include "libm.h"
 
 #if LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024
-long double frexpl(long double x, int *e)
+double frexpl(double x, int *e)
 {
 	return frexp(x, e);
 }
 #elif (LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113) && LDBL_MAX_EXP == 16384
-long double frexpl(long double x, int *e)
+double frexpl(double x, int *e)
 {
 	union ldshape u = {x};
 	int ee = u.i.se & 0x7fff;


### PR DESCRIPTION
This is to avoid calls to libgcc soft-fp with which we are binary incompatible.